### PR TITLE
Proxy attributes to underlying file

### DIFF
--- a/bom_open/bom_open.py
+++ b/bom_open/bom_open.py
@@ -23,40 +23,61 @@ class bom_open():
 
         self.mode = mode
         self.buffering = buffering
-        self.encoding = encoding
+        self._encoding = encoding
         self.args = args
         self.kwargs = kwargs
+        self._f = None
 
     def __enter__(self):
         if self.file:
-            self._f = open(self.file, self.mode, self.buffering, self.encoding,
+            self._f = open(self.file, self.mode, self.buffering, self._encoding,
                            *self.args, **self.kwargs)
         elif self.mode == 'r':
             self._f = sys.stdin
         elif self.mode == 'w':
-            if self.encoding:
+            if self._encoding:
                 sys.stdout = open(sys.stdout.fileno(), 'w',
-                                  encoding=self.encoding,
+                                  encoding=self._encoding,
                                   buffering=1)
             self._f = sys.stdout
         else:
             raise StdIOError('No file specified, and mode not appropriate '
                              'for stdin (r) or stdout (w)')
 
-        if (self.encoding is None
+        if (self._encoding is None
             and 'b' not in self.mode
             and ('r' in self.mode or '+' in self.mode)):
             # run chardet on buffer without advancing file position
             peek = self._f.buffer.peek()
             detected = chardet.detect(peek)
-            self.encoding = detected['encoding']
+            self._encoding = detected['encoding']
 
             # re-attach file with detected encoding
-            if (self._f.encoding.lower() != (self.encoding or '').lower()):
+            if (self._f.encoding.lower() != (self._encoding or '').lower()):
                 self._f = TextIOWrapper(self._f.detach(),
-                                        encoding=self.encoding)
+                                        encoding=self._encoding)
 
         return self._f
 
     def __exit__(self, type, value, traceback):
         self._f.close()
+
+    def __getattr__(self, name):
+        if self._f is None:
+            self.__enter__()
+
+        return getattr(self._f, name)
+
+    def close(self):
+        if self._f is not None:
+            self._f.close()
+            self._f = None
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self._f is None:
+            self.__enter__()
+
+        return next(self._f)

--- a/tests/test_open.py
+++ b/tests/test_open.py
@@ -11,9 +11,9 @@ def _get_test_filename(name):
     return os.path.join(_tests_base, name)
 
 
-class TestBomOpen(unittest.TestCase):
+class TestContextManagerOpenFile(unittest.TestCase):
 
-    def test_utf8le(self):
+    def test_utf8sig(self):
         with bom_open(_get_test_filename('bom8-sig.txt')) as f:
             self.assertEqual(f.encoding.lower(), 'utf-8-sig')
             contents = f.read()
@@ -60,3 +60,12 @@ class TestBomOpen(unittest.TestCase):
             self.assertEqual(f.encoding.lower(), 'utf-8')
             contents = f.read()
         self.assertEqual(contents, '己所不欲，勿施於人。')
+
+
+class TestNormalOpenFile(unittest.TestCase):
+
+    def test_utf8sig(self):
+        f = bom_open(_get_test_filename('bom8-sig.txt'))
+        self.assertEqual(f.encoding.lower(), 'utf-8-sig')
+        contents = f.read()
+        self.assertEqual(contents, 'hello\n')


### PR DESCRIPTION
When bom_open is not used as a context manager, the class can emulate
a file object and enter/exit when required.